### PR TITLE
Added out-of-line definition for profileIndexName and filesIndexName

### DIFF
--- a/src/profiles/profilesmanager.cpp
+++ b/src/profiles/profilesmanager.cpp
@@ -10,6 +10,10 @@
 
 namespace Ttyh {
 namespace Profiles {
+
+constexpr const char *ProfilesManager::profileIndexName;
+constexpr const char *ProfilesManager::filesIndexName;
+
 ProfilesManager::ProfilesManager(QString workDir, const QSharedPointer<Logs::Logger> &logger)
     : dataPath(std::move(workDir)),
       log(logger, "Profiles")


### PR DESCRIPTION
The linker was unable to find the symbols' definitions for those two variables.

```
Undefined symbols for architecture x86_64:
  "Ttyh::Profiles::ProfilesManager::filesIndexName", referenced from:
      Ttyh::Profiles::ProfilesManager::installFiles(QString const&, Ttyh::Versions::FullVersionId const&) in profilesmanager.cpp.o
  "Ttyh::Profiles::ProfilesManager::profileIndexName", referenced from:
      Ttyh::Profiles::ProfilesManager::ProfilesManager(QString, QSharedPointer<Ttyh::Logs::Logger> const&) in profilesmanager.cpp.o
      Ttyh::Profiles::ProfilesManager::create(QString const&, Ttyh::Profiles::ProfileData const&) in profilesmanager.cpp.o
      Ttyh::Profiles::ProfilesManager::update(QString const&, Ttyh::Profiles::ProfileData const&) in profilesmanager.cpp.o
ld: symbol(s) not found for architecture x86_64
```

Adding a definition in profilesmanager.cpp has solved the issue.